### PR TITLE
Add get_grammar_names method to registry struct

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -316,8 +316,9 @@ impl Registry {
         Ok((tokens, tokenizer.into_scope_interner()))
     }
 
-    /// Output the name and aliases of all grammars in the registry
-    pub fn supported_languages(&self) -> Vec<(String, Vec<String>)> {
+    /// Gets the name and aliases of all grammars in the registry
+    /// Outputs a vector of tuples of the form (Name, Aliases)
+    pub fn get_grammar_names(&self) -> Vec<(String, Vec<String>)> {
         self.grammars.iter().map(|grammar|
             (grammar.name.clone(), grammar.aliases.clone())).collect()
     }
@@ -752,10 +753,10 @@ mod tests {
             .unwrap();
         registry.add_alias("shellscript", "bash");
 
-        assert_eq!(registry.supported_languages(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap()])]);
+        assert_eq!(registry.get_grammar_names(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap()])]);
 
         registry.add_alias("shellscript", "bashs");
-        assert_eq!(registry.supported_languages(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap(), "bashs".parse().unwrap()])]);
+        assert_eq!(registry.get_grammar_names(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap(), "bashs".parse().unwrap()])]);
     }
 
     #[cfg(feature = "dump")]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -122,8 +122,8 @@ pub(crate) fn normalize_string(s: &str) -> String {
 
 #[derive(Debug, PartialEq)]
 pub struct GrammarNameAndAliases<'a> {
-    pub name: &'a String,
-    pub aliases: &'a Vec<String>,
+    pub name: &'a str,
+    pub aliases: &'a [String],
 }
 
 /// The main struct in giallo.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -316,6 +316,12 @@ impl Registry {
         Ok((tokens, tokenizer.into_scope_interner()))
     }
 
+    /// Output the name and aliases of all grammars in the registry
+    pub fn supported_languages(&self) -> Vec<(String, Vec<String>)> {
+        self.grammars.iter().map(|grammar|
+            (grammar.name.clone(), grammar.aliases.clone())).collect()
+    }
+
     /// Checks whether the given lang is available in the registry with its grammar name
     /// or aliases
     pub fn contains_grammar(&self, name: &str) -> bool {
@@ -736,6 +742,20 @@ mod tests {
         }
 
         out
+    }
+
+    #[test]
+    fn supported_languages() {
+        let mut registry = Registry::default();
+        registry
+            .add_grammar_from_path("grammars-themes/packages/tm-grammars/grammars/shellscript.json")
+            .unwrap();
+        registry.add_alias("shellscript", "bash");
+
+        assert_eq!(registry.supported_languages(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap()])]);
+
+        registry.add_alias("shellscript", "bashs");
+        assert_eq!(registry.supported_languages(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap(), "bashs".parse().unwrap()])]);
     }
 
     #[cfg(feature = "dump")]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -120,6 +120,12 @@ pub(crate) fn normalize_string(s: &str) -> String {
     s.replace("\r\n", "\n").replace('\r', "\n")
 }
 
+#[derive(Debug, PartialEq)]
+pub struct GrammarNameAndAliases<'a> {
+    pub name: &'a String,
+    pub aliases: &'a Vec<String>,
+}
+
 /// The main struct in giallo.
 ///
 /// Holds all the grammars and themes and is responsible for highlighting a text. It is not
@@ -317,10 +323,16 @@ impl Registry {
     }
 
     /// Gets the name and aliases of all grammars in the registry
-    /// Outputs a vector of tuples of the form (Name, Aliases)
-    pub fn get_grammar_names(&self) -> Vec<(String, Vec<String>)> {
-        self.grammars.iter().map(|grammar|
-            (grammar.name.clone(), grammar.aliases.clone())).collect()
+    pub fn get_grammar_names(&'_ self) -> Vec<GrammarNameAndAliases<'_>> {
+        self.grammars
+            .iter()
+            .map(|grammar| {
+                GrammarNameAndAliases {
+                    name: &grammar.name,
+                    aliases: &grammar.aliases,
+                }
+            })
+            .collect()
     }
 
     /// Checks whether the given lang is available in the registry with its grammar name
@@ -753,10 +765,22 @@ mod tests {
             .unwrap();
         registry.add_alias("shellscript", "bash");
 
-        assert_eq!(registry.get_grammar_names(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap()])]);
+        assert_eq!(
+            registry.get_grammar_names(),
+            vec![GrammarNameAndAliases {
+                name: &String::from("shellscript"),
+                aliases: &vec![String::from("bash")],
+            }]
+        );
 
         registry.add_alias("shellscript", "bashs");
-        assert_eq!(registry.get_grammar_names(), vec![("shellscript".parse().unwrap(), vec!["bash".parse().unwrap(), "bashs".parse().unwrap()])]);
+        assert_eq!(
+            registry.get_grammar_names(),
+            vec![GrammarNameAndAliases {
+                name: &String::from("shellscript"),
+                aliases: &vec![String::from("bash"), String::from("bashs")],
+            }]
+        );
     }
 
     #[cfg(feature = "dump")]


### PR DESCRIPTION
A small PR that adds a getter function to the registry struct to output all contained grammar names and their aliases. 

Purpose: 
I am working on integrating giallo into [typst](https://github.com/typst/typst) to replace syntect. In order to allow for auto completion of the available grammars, the default grammar name/alias list need to be generated. Since it can change for every new version of the builtin registry, a consistent getter is required. 

I believe this functionality does not exist in the current version of giallo. 

Tests: 
A testcase has been added to ensures this method works. 

Improvements could be made to allow for more read assess to the internal registry data. 

No AI was used in the writing of this code. 